### PR TITLE
Add an "Edit client" option

### DIFF
--- a/src/application/handlers.rs
+++ b/src/application/handlers.rs
@@ -238,4 +238,41 @@ mod test {
 
         assert_eq!(Ok(()), result);
     }
+
+    #[test]
+    fn edit_client_use_case_handler_execute_on_non_existing_client() {
+        let client: Client = Faker.fake();
+
+        let id = client.id.clone();
+        let id3 = id.clone();
+
+        let new_name: String = Faker.fake();
+        let new_location: String = Faker.fake();
+
+        let error_txt: String = Sentence(3..8).fake();
+
+        let mut client_repository_mock = MockClientRepository::new();
+
+        client_repository_mock
+            .expect_by_id()
+            .withf(move |x: &str| x.eq(id.as_str()))
+            .times(1)
+            .return_const(Err(error_txt.clone()));
+
+        client_repository_mock
+            .expect_save()
+            .times(0)
+            .return_const(());
+
+        let edit_client_use_case_handler =
+            EditClientUseCaseHandler::new(Rc::new(client_repository_mock));
+
+        let result = edit_client_use_case_handler.execute(EditClientUseCaseRequest::new(
+            id3.as_str(),
+            new_name.as_str(),
+            new_location.as_str(),
+        ));
+
+        assert_eq!(Err(error_txt), result);
+    }
 }

--- a/src/application/requests.rs
+++ b/src/application/requests.rs
@@ -25,3 +25,20 @@ impl GetClientUseCaseRequest {
         }
     }
 }
+
+#[readonly::make]
+pub struct EditClientUseCaseRequest {
+    pub client_id: String,
+    pub name: String,
+    pub location: String,
+}
+
+impl EditClientUseCaseRequest {
+    pub fn new(client_id: &str, name: &str, location: &str) -> Self {
+        Self {
+            client_id: client_id.to_string(),
+            name: name.to_string(),
+            location: location.to_string(),
+        }
+    }
+}

--- a/src/domain/entities.rs
+++ b/src/domain/entities.rs
@@ -1,6 +1,6 @@
 use fake::{Dummy, Fake};
 
-#[derive(Clone, Dummy)]
+#[derive(Clone, Dummy, PartialEq, Eq)]
 #[readonly::make]
 pub struct Client {
     pub id: String,
@@ -15,6 +15,11 @@ impl Client {
             name: name.to_string(),
             location: location.to_string(),
         }
+    }
+
+    pub fn edit(&mut self, name: &str, location: &str) {
+        self.name = name.to_string();
+        self.location = location.to_string();
     }
 }
 
@@ -34,5 +39,23 @@ mod test {
         assert_eq!(client.id, id.as_str());
         assert_eq!(client.name, name.as_str());
         assert_eq!(client.location, location.as_str());
+    }
+
+    #[test]
+    fn edit_client() {
+        let mut client: Client = Faker.fake();
+        let id = client.id.clone();
+
+        let new_name: String = Faker.fake();
+        let new_location: String = Faker.fake();
+
+        assert_ne!(client.name, new_name);
+        assert_ne!(client.location, new_location);
+
+        client.edit(new_name.as_str(), new_location.as_str());
+
+        assert_eq!(client.id, id);
+        assert_eq!(client.name, new_name);
+        assert_eq!(client.location, new_location);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 extern crate core;
 extern crate proc_macro;
 
+use crate::application::handlers::EditClientUseCaseHandler;
+use crate::application::requests::EditClientUseCaseRequest;
 use crate::presentation::prompt::{ask_question, menu};
 use application::handlers::{
     CreateClientUseCaseHandler, GetAllClientsUseCaseHandler, GetClientUseCaseHandler,
@@ -20,14 +22,20 @@ fn main() {
     let get_all_clients_use_case_handler =
         GetAllClientsUseCaseHandler::new(client_repository.clone());
     let get_client_use_case_handler = GetClientUseCaseHandler::new(client_repository.clone());
-    let create_client_use_case_handler = CreateClientUseCaseHandler::new(client_repository);
+    let create_client_use_case_handler = CreateClientUseCaseHandler::new(client_repository.clone());
+    let edit_client_use_case_handler = EditClientUseCaseHandler::new(client_repository);
 
     while {
         let option: u8 = menu(
             std::io::stdin().lock(),
             std::io::stdout(),
             std::io::stderr(),
-            vec!["List all clients", "Read a client", "Create a client"],
+            vec![
+                "List all clients",
+                "Read a client",
+                "Create a client",
+                "Edit a client",
+            ],
         );
 
         match option {
@@ -74,6 +82,35 @@ fn main() {
                 create_client_use_case_handler.execute(create_client_use_case_req);
 
                 println!("\nClient created!");
+            }
+
+            4 => {
+                let client_id = ask_question(
+                    std::io::stdin().lock(),
+                    std::io::stdout(),
+                    "Please, enter the ID of the client that you want to read:",
+                );
+
+                let client_name = ask_question(
+                    std::io::stdin().lock(),
+                    std::io::stdout(),
+                    "\nEnter the new name of the client:",
+                );
+                let client_location = ask_question(
+                    std::io::stdin().lock(),
+                    std::io::stdout(),
+                    "\nEnter the new location of the client:",
+                );
+
+                let result = edit_client_use_case_handler.execute(EditClientUseCaseRequest::new(
+                    client_id.as_str(),
+                    client_name.as_str(),
+                    client_location.as_str(),
+                ));
+
+                if let Err(e) = result {
+                    eprintln!("ERROR: {}", e);
+                }
             }
 
             0 => println!("Exiting..."),

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,8 +108,9 @@ fn main() {
                     client_location.as_str(),
                 ));
 
-                if let Err(e) = result {
-                    eprintln!("ERROR: {}", e);
+                match result {
+                    Ok(_) => println!("\nClient edited!"),
+                    Err(e) => eprintln!("\nERROR: {}", e),
                 }
             }
 


### PR DESCRIPTION
As requested in #2, this PR implements an "Edit client" option in the menu, in which you can perform changes on existing clients.